### PR TITLE
fix: Terminating Boundary

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express-prep",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "A Connect/Express style middleware for the Per Resource Events Protocol",
   "keywords": [
     "per resource events",

--- a/src/prep.js
+++ b/src/prep.js
@@ -330,8 +330,8 @@ function prepMiddleware(req, res, next) {
     function writeEnd() {
       notifications.push(
         dedent`
-          \n--${digestBoundary}--
-          ${mixedBoundary ? `--${mixedBoundary}--` : ""}
+          --${digestBoundary}--
+          --${mixedBoundary}--\n
         `.replace(/\n/g, "\r\n"),
       );
       res.end();


### PR DESCRIPTION
Removed leading linebreak before the digest boundary, as the blank line can confuse less tolerant multipart parsers.

We no longer test for the mixed boundary (as the mixed boundary is always there by virtue of the previous commit).

Trailing linebreak added to mixed boundary, as http messages are expected to canonically end with linebreak.